### PR TITLE
fix parsing verbose option as socket port

### DIFF
--- a/Emulator/RetroShell/RetroShellCmds.cpp
+++ b/Emulator/RetroShell/RetroShellCmds.cpp
@@ -1401,7 +1401,7 @@ RetroShell::exec <Token::server, Token::gdb, Token::set, Token::port> (Arguments
 template <> void
 RetroShell::exec <Token::server, Token::gdb, Token::set, Token::verbose> (Arguments& argv, long param)
 {
-    remoteManager.gdbServer.setConfigItem(OPT_SRV_PORT, util::parseBool(argv.front()));
+    remoteManager.gdbServer.setConfigItem(OPT_SRV_VERBOSE, util::parseBool(argv.front()));
 }
 
 template <> void


### PR DESCRIPTION
Just a little fix, for the GDBServer configuration launched by script.