### PR TITLE
Initial stack pointer should be in a7

### DIFF
--- a/Emulator/Components/CPU/CPU.cpp
+++ b/Emulator/Components/CPU/CPU.cpp
@@ -370,6 +370,7 @@ CPU::_didReset(bool hard)
         
         // Initialize all data and address registers with the startup value
         for(int i = 0; i < 8; i++) reg.d[i] = reg.a[i] = config.regResetVal;
+        reg.a[7] = reg.isp;
         
         // Remove all previously recorded instructions
         debugger.clearLog();


### PR DESCRIPTION
The A7 register should use the entry 0 of the vector table after a cold reset. If you use a custom ROM that depends on that a crash follows otherwise.