### PR TITLE
Add audio state transitions 2,3 -> 0 to disableDMA()

### DIFF
--- a/Emulator/Components/Paula/Audio/StateMachine.cpp
+++ b/Emulator/Components/Paula/Audio/StateMachine.cpp
@@ -77,6 +77,16 @@ StateMachine<nr>::disableDMA()
 
             move_001_000();
             break;
+            
+        case 0b010:
+            
+            move_010_000();
+            break;
+            
+        case 0b011:
+            
+            move_011_000();
+            break;
 
         case 0b101:
 
@@ -307,6 +317,18 @@ StateMachine<nr>::move_010_011() {
 
     state = 0b011;
     penlo();
+}
+
+template <isize nr> void
+StateMachine<nr>::move_010_000() {
+
+    trace(AUD_DEBUG, "move_010_000\n");
+
+    constexpr EventSlot slot = (EventSlot)(SLOT_CH0 + nr);
+    agnus.cancel<slot>();
+
+    intreq2 = false;
+    state = 0b000;
 }
 
 template <isize nr> void

--- a/Emulator/Components/Paula/Audio/StateMachine.h
+++ b/Emulator/Components/Paula/Audio/StateMachine.h
@@ -278,6 +278,7 @@ private:
     void move_101_010();
     void move_010_011();
     void move_011_000();
+    void move_010_000();
     void move_011_010();
 
     


### PR DESCRIPTION
When disabling the audio DMA the state machine does not return to state 0. If audio DMA is reenabled the audio "latches" are then not read, because the state machine does not start from state 0. This causes missed sounds for play out.

The attached kick ROM shows two pink balls which when just out of sight invert their direction and play a sound on channel 0, otherwise "silence" is being played out. Without the change from time to time no sound can be heard. With the change the sound is always played out, there aren't any misses.

[game.a.zip](https://github.com/user-attachments/files/16558519/game.a.zip)
