### PR TITLE
Prevent crash when disassembling Copper list without recorded data

### DIFF
--- a/Core/Components/Agnus/Copper/CopperDebugger.cpp
+++ b/Core/Components/Agnus/Copper/CopperDebugger.cpp
@@ -191,6 +191,10 @@ CopperDebugger::disassemble(std::ostream &os, isize list, bool symbolic, isize m
     assert(list == 1 || list == 2);
     
     auto prog = list == 1 ? current1 : current2;
+    if (!prog) {
+        os << "No recorded data. Debug mode is off." << std::endl;
+        return;
+    }
     auto cnt  = isize(prog->end - prog->start) / 4;
     auto addr = u32(list == 1 ? copper.cop1lc : copper.cop2lc);
     


### PR DESCRIPTION
  - Add a guard in CopperDebugger::disassemble to handle missing cached
    lists gracefully.
  - When no Copper list is recorded, the command now returns a clear message
    instead of dereferencing a null pointer.

  Testing:

  - manual check: run ? copper list 1 before any Copper tracking.