### PR TITLE
🐛 include <climits> to define INT/LONG_MAX

### DIFF
--- a/Core/Components/Agnus/DmaDebugger/Beamtraps.cpp
+++ b/Core/Components/Agnus/DmaDebugger/Beamtraps.cpp
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "Beamtraps.h"
 #include "Amiga.h"
+#include <climits>
 
 namespace vamiga {
 

--- a/Core/Components/Agnus/Sequencer/SequencerBpl.cpp
+++ b/Core/Components/Agnus/Sequencer/SequencerBpl.cpp
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "Sequencer.h"
 #include "Agnus.h"
+#include <climits>
 
 namespace vamiga {
 

--- a/Core/Misc/RetroShell/CBMNavigator.cpp
+++ b/Core/Misc/RetroShell/CBMNavigator.cpp
@@ -16,6 +16,7 @@
 #include "utl/chrono.h"
 #include "utl/support.h"
 #include "utl/io.h"
+#include <climits>
 #include <format>
 #include <regex>
 

--- a/Core/Misc/RetroShell/NavigatorConsole.cpp
+++ b/Core/Misc/RetroShell/NavigatorConsole.cpp
@@ -16,6 +16,7 @@
 #include "utl/chrono.h"
 #include "utl/support.h"
 #include "utl/io.h"
+#include <climits>
 #include <regex>
 
 namespace vamiga {

--- a/Core/Peripherals/Joystick/Joystick.cpp
+++ b/Core/Peripherals/Joystick/Joystick.cpp
@@ -11,6 +11,7 @@
 #include "Joystick.h"
 #include "Amiga.h"
 #include "utl/io.h"
+#include <climits>
 #include <sstream>
 
 namespace vamiga {


### PR DESCRIPTION
newer gcc and clang seem to require this:

```
/home/mop/projects/akronyme-analogiker/vAmiga/Core/Misc/RetroShell/CBMNavigator.cpp:762:84: error: use of undeclared identifier 'LONG_MAX'
  762 |                 auto lines = args.contains("lines") ? parseNum(args.at("lines")) : LONG_MAX;
      |                                                                                    ^~~~~~~~
/home/mop/projects/akronyme-analogiker/vAmiga/Core/Misc/RetroShell/CBMNavigator.cpp:830:84: error: use of undeclared identifier 'LONG_MAX'
  830 |                 auto lines = args.contains("lines") ? parseNum(args.at("lines")) : LONG_MAX;
      |                                                                                    ^~~~~~~~
```

etcetc. :scream: 