### PR TITLE
Add explicit bootable flag for hard drives

### DIFF
--- a/Core/Peripherals/Drive/DriveTypes.h
+++ b/Core/Peripherals/Drive/DriveTypes.h
@@ -23,13 +23,14 @@ using namespace retro::vault;
 enum class DiskFlags
 {
     PROTECTED  = 1,
-    MODIFIED   = 2
+    MODIFIED   = 2,
+    BOOTABLE   = 4
 };
 
 struct DiskFlagsEnum : Reflectable<DiskFlagsEnum, DiskFlags>
 {
     static constexpr long minVal = 1;
-    static constexpr long maxVal = long(DiskFlags::MODIFIED);
+    static constexpr long maxVal = long(DiskFlags::BOOTABLE);
     
     static const char *_key(DiskFlags value)
     {
@@ -37,6 +38,7 @@ struct DiskFlagsEnum : Reflectable<DiskFlagsEnum, DiskFlags>
                 
             case DiskFlags::PROTECTED:    return "PROTECTED";
             case DiskFlags::MODIFIED:     return "MODIFIED";
+            case DiskFlags::BOOTABLE:     return "BOOTABLE";
         }
         return "???";
     }
@@ -46,6 +48,7 @@ struct DiskFlagsEnum : Reflectable<DiskFlagsEnum, DiskFlags>
                 
             case DiskFlags::PROTECTED:    return "Write protected disk";
             case DiskFlags::MODIFIED:     return "Modified disk contents";
+            case DiskFlags::BOOTABLE:     return "Bootable disk";
         }
         return "???";
     }

--- a/Core/Peripherals/Drive/HardDrive.cpp
+++ b/Core/Peripherals/Drive/HardDrive.cpp
@@ -88,6 +88,7 @@ HardDrive::init()
     ptable.clear();
     drivers.clear();
     head = {};
+    setFlag(DiskFlags::BOOTABLE, false);
     setFlag(DiskFlags::MODIFIED, force::HDR_MODIFIED);
 }
 
@@ -111,6 +112,9 @@ HardDrive::init(const GeometryDescriptor &geometry)
     
     // Add the descriptor to the partition table
     ptable.push_back(partition);
+
+    // User-provided disks are bootable by default
+    setFlag(DiskFlags::BOOTABLE, true);
 
     // Create the new drive
     data.init(geometry.numBytes(), 0);
@@ -311,6 +315,7 @@ HardDrive::connect()
         loginfo(WT_DEBUG, "Creating default disk...\n");
         init(MB(10));
         format(amiga::FSFormat::OFS, FSName(defaultName()));
+        setFlag(DiskFlags::BOOTABLE, false);
     }
 }
 
@@ -342,24 +347,7 @@ HardDrive::isCompatible() const
 bool
 HardDrive::isBootable()
 {
-    try {
-
-        auto vol = Volume(*this);
-        auto fs = FileSystem(vol);
-
-        if (fs.exists("s/startup-sequence")) {
-
-            loginfo(HDR_DEBUG, "Bootable drive\n");
-            return true;
-        }
-        
-    } catch (...) {
-        
-        loginfo(HDR_DEBUG, "No file system found\n");
-    }
-    
-    loginfo(HDR_DEBUG, "Unbootable drive\n");
-    return false;
+    return hasDisk() && getFlag(DiskFlags::BOOTABLE);
 }
 
 HardDriveInfo

--- a/Core/Peripherals/Drive/HardDrive.h
+++ b/Core/Peripherals/Drive/HardDrive.h
@@ -370,7 +370,7 @@ public:
     // Checks whether the drive will work with the currently installed Rom
     bool isCompatible() const;
        
-    // Checks whether the drive is bootable
+    // Checks whether the drive is marked as bootable
     bool isBootable();
     
     //

--- a/GUI/Dialogs/HardDiskConfigurator.swift
+++ b/GUI/Dialogs/HardDiskConfigurator.swift
@@ -25,6 +25,7 @@ class HardDiskConfigurator: DialogController {
     @IBOutlet weak var sectorStepper: NSStepper!
 
     @IBOutlet weak var warningText: NSTextField!
+    @IBOutlet weak var bootableCheckbox: NSButton!
     @IBOutlet weak var okButton: NSButton!
 
     var nr = 0
@@ -104,6 +105,7 @@ class HardDiskConfigurator: DialogController {
         headStepper.maxValue = .greatestFiniteMagnitude
         sectorStepper.maxValue = .greatestFiniteMagnitude
         warningText.textColor = .warning
+        bootableCheckbox.state = drive.getFlag(.BOOTABLE) ? .on : .off
 
         geometryPopup.removeAllItems()
         geometryPopup.addItem(withTitle: "Custom")
@@ -235,6 +237,7 @@ class HardDiskConfigurator: DialogController {
         
         do {
             try drive.changeGeometry(c: cyls, h: heads, s: sectors)
+            drive.setFlag(.BOOTABLE, value: bootableCheckbox.state == .on)
             hide()
             
         } catch {

--- a/GUI/MyControllerMenu.swift
+++ b/GUI/MyControllerMenu.swift
@@ -106,6 +106,10 @@ extension MyController: NSMenuItemValidation {
         case #selector(MyController.writeProtectHdrAction(_:)):
             item.state = hdn.info.hasProtectedDisk ? .on : .off
             return hdn.info.hasDisk
+
+        case #selector(MyController.bootableHdrAction(_:)):
+            item.state = hdn.getFlag(.BOOTABLE) ? .on : .off
+            return hdn.info.hasDisk
             
         default:
             return item.isEnabled
@@ -735,6 +739,13 @@ extension MyController: NSMenuItemValidation {
         
         if let hdn = emu?.hd(sender) {
             hdn.setFlag(.PROTECTED, value: !hdn.getFlag(.PROTECTED))
+        }
+    }
+
+    @IBAction func bootableHdrAction(_ sender: NSMenuItem!) {
+
+        if let hdn = emu?.hd(sender) {
+            hdn.setFlag(.BOOTABLE, value: !hdn.getFlag(.BOOTABLE))
         }
     }
     

--- a/GUI/XIB files/HardDiskConfigurator.xib
+++ b/GUI/XIB files/HardDiskConfigurator.xib
@@ -8,6 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="HardDiskConfigurator">
             <connections>
+                <outlet property="bootableCheckbox" destination="QdC-9g-BtL" id="GHy-4X-TdP"/>
                 <outlet property="cylinderField" destination="Ivb-fr-DFo" id="bLv-P4-9E5"/>
                 <outlet property="cylinderStepper" destination="xXY-el-Faf" id="kHR-PH-bBA"/>
                 <outlet property="cylinderText" destination="eSF-5b-pdf" id="D2l-rz-2fe"/>
@@ -169,6 +170,14 @@ Gw
                             <action selector="geometryAction:" target="-2" id="yl9-4R-rjC"/>
                         </connections>
                     </popUpButton>
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QdC-9g-BtL">
+                        <rect key="frame" x="164" y="125" width="88" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Bootable" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="ad9-Yt-7FL">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="system"/>
+                        </buttonCell>
+                    </button>
                     <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tpR-nX-JuM">
                         <rect key="frame" x="501" y="13" width="85" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>

--- a/GUI/XIB files/en.lproj/MainMenu.xib
+++ b/GUI/XIB files/en.lproj/MainMenu.xib
@@ -624,6 +624,12 @@ CQ
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="ieg-NM-Vj2"/>
+                            <menuItem title="Bootable" id="fH0-Bt-978">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="bootableHdrAction:" target="-1" id="fH0-Bt-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Write Protected" id="73e-Wr-cMm">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -683,6 +689,12 @@ CQ
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="8e1-0R-Xgb"/>
+                            <menuItem title="Bootable" tag="1" id="fH1-Bt-978">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="bootableHdrAction:" target="-1" id="fH1-Bt-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Write Protected" tag="1" id="LFK-jK-NPP" userLabel="Export disk">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -742,6 +754,12 @@ CQ
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="BA5-MK-XXw"/>
+                            <menuItem title="Bootable" tag="2" id="fH2-Bt-978">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="bootableHdrAction:" target="-1" id="fH2-Bt-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Write Protected" tag="2" id="KcH-ih-oZX" userLabel="Export disk">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
@@ -801,6 +819,12 @@ CQ
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="tzT-rv-xwa"/>
+                            <menuItem title="Bootable" tag="3" id="fH3-Bt-978">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="bootableHdrAction:" target="-1" id="fH3-Bt-act"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Write Protected" tag="3" id="Xmj-KC-ZiU" userLabel="Export disk">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>


### PR DESCRIPTION
Fixes #978.

Adds an explicit bootable flag for hard drives, avoiding filesystem inspection that fails with unsupported or custom filesystems. Attached
HDFs default to bootable, while generated placeholder disks do not. The flag can be changed through the HD menu or hard-disk configurator.

Tested with the affected HDFs; all core tests and the Xcode build pass.

