### PR TITLE
Write block checksums for empty files and directories

### DIFF
--- a/Core/rvlib/FileSystems/Amiga/FileSystemLayer2.cpp
+++ b/Core/rvlib/FileSystems/Amiga/FileSystemLayer2.cpp
@@ -172,6 +172,10 @@ FileSystem::mkdir(BlockNr at, const FSName &name)
     fetch(udb).mutate().setParentDirRef(at);
     addToHashTable(at, udb);
 
+    // Same as createFile: an empty directory is never mutated again, so its
+    // checksum must be written here.
+    fetch(udb).mutate().updateChecksum();
+
     return udb;
 }
 
@@ -307,6 +311,11 @@ FileSystem::createFile(BlockNr at, const FSName &name)
     try {
 
         link(at, fhb);
+
+        // Checksums are otherwise only written as a side effect of a later
+        // mutation, so a file that never receives data keeps a zero checksum
+        // and AmigaDOS rejects the volume.
+        fetch(fhb).mutate().updateChecksum();
         return fhb;
 
     } catch(...) {


### PR DESCRIPTION
### Problem

A volume built with `importFiles()` / `FSImporter` is rejected by AmigaDOS at runtime with

```
<volume> has a checksum error on disk block N
```

if the imported tree contains a **zero-length file** or an **empty directory**. The
guest cannot read the volume, so games fail to load.

This is easy to hit in practice: the WHDLoad install of Cannon Fodder ships an
empty `data/Save` file, and any imported tree containing an empty directory does
it too.

### Cause

Block checksums are only written as a side effect of a *later* mutation:

- a file that receives data gets one via `replace()`
- a directory that receives a child gets one when the child is linked

A zero-length file or an empty directory is never mutated after creation, so its
header block keeps a zero checksum.

`FSImporter::import()` appears to have had a sweep that would have covered this,
but the call is commented out and the method no longer exists:

```cpp
// Rectify the checksums of all blocks
// fs.importer.updateChecksums();
```

### Fix

Write the checksum at the end of `FileSystem::createFile(BlockNr, const FSName &)`
and `FileSystem::mkdir()`.

I first tried the tidier-looking placement — in `newFileHeaderBlock()` and
`newUserDirBlock()` — but that does not work: both callers mutate the block
afterwards (`setParentDirRef`, `addToHashTable`, `link`), which invalidates a
checksum written at construction time. It has to happen after those.

### Verification

Building the same volume with and without an empty entry, then validating every
header block in the exported HDF:

| volume contents | header blocks with an invalid checksum |
|---|---|
| clean | 0 |
| + one zero-length file | 1 |
| + one empty directory | 1 |
| + both | 2 |
| any of the above, with this patch | **0** |

`ctest` passes (3/3). With the patch applied, Cannon Fodder boots to its mission
screen instead of failing on the checksum error.

Found while embedding `VACore` in a launcher, so the reproduction is via the
public `HardDriveAPI` (`attach` → `format` → `importFiles` → `writeToFile`)
rather than the GUI.
