### PR TITLE
Rectify remaining file header (MPL license)

### DIFF
--- a/Core/Media/FloppyFile.h
+++ b/Core/Media/FloppyFile.h
@@ -2,9 +2,9 @@
 // This file is part of vAmiga
 //
 // Copyright (C) Dirk W. Hoffmann. www.dirkwhoffmann.de
-// Licensed under the GNU General Public License v3
+// Licensed under the Mozilla Public License v2
 //
-// See https://www.gnu.org for license information
+// See https://mozilla.org/MPL/2.0 for license information
 // -----------------------------------------------------------------------------
 
 #pragma once


### PR DESCRIPTION
Following #1017 - thanks for sorting that out so quickly.

One file looks to have been missed: `Core/Media/FloppyFile.h` still carries the
GPL-3 header. It is the only remaining copyleft header under `Core`.

It is a vAmiga file rather than a RetroVault one, so I have matched its sibling
`Core/Media/AnyFile.h` - keeping the "This file is part of vAmiga" line and
changing only the licence - rather than the RetroVault wording used in
`rvlib/Images`. The header is now byte-identical to `AnyFile.h`'s.

With this, `grep -rl "General Public License" Core` comes back empty.
